### PR TITLE
Update the language reference

### DIFF
--- a/docs/reference/expressions_and_operators.md
+++ b/docs/reference/expressions_and_operators.md
@@ -21,11 +21,12 @@ Expressions in Ovum include literal values, variable references, function calls,
 * `&&` (logical AND) - short-circuit evaluation
 * `||` (logical OR) - short-circuit evaluation
 * `!` (negation) - unary operator
-* `xor` (exclusive OR) - infix operator on `Bool`
+* `xor` (exclusive OR) - infix operator on `bool`
 
-## Assignment Operator
+## Assignment Operators
 
-* `=` (assignment) - assigns a value to a mutable variable or field. The left-hand side must be a mutable variable or field.
+* `=` (reference assignment) - assigns a reference to a mutable variable or field. The left-hand side must be a mutable variable or field.
+* `:=` (copy assignment) - performs deep copy for reference types. Creates a new object with the same content as the source.
 
 ## Member Access
 
@@ -37,13 +38,12 @@ Expressions in Ovum include literal values, variable references, function calls,
 ## Type Operations
 
 * `expr as Type` - explicit cast (downcast yields nullable type)
-* `expr is Type` - type test (returns `Bool`)
+* `expr is Type` - type test (returns `bool`)
 
 ## Null Handling
 
 * `expr?.member` - safe call (calls only if expr is not null)
 * `expr ?: default` - Elvis operator (returns expr if not null, otherwise default)
-* `expr!!` - non-null assertion (throws error if expr is null)
 
 ## Namespace Resolution
 

--- a/docs/reference/lexical_structure.md
+++ b/docs/reference/lexical_structure.md
@@ -24,8 +24,8 @@ Ovum reserves certain words like `fun`, `class`, `interface`, `var`, `override`,
 * **Arithmetic**: `+`, `-`, `*`, `/`, `%`
 * **Comparison**: `==`, `!=`, `<`, `<=`, `>`, `>=`
 * **Boolean logic**: `&&` (logical AND), `||` (logical OR), `!` (negation), `xor` (exclusive OR)
-* **Assignment**: `=`
-* **Null handling**: `?.` (safe call), `?:` (Elvis), `!!` (non-null assertion)
+* **Assignment**: `=` (reference assignment), `:=` (copy assignment)
+* **Null handling**: `?.` (safe call), `?:` (Elvis)
 * **Type operations**: `as` (cast), `is` (type test)
 * **Punctuation**: `,` (comma), `;` (semicolon), `:` (colon), `()` (parentheses), `{}` (braces), `[]` (brackets)
 * **Namespace resolution**: `::`
@@ -87,14 +87,16 @@ TypeAliasDecl   ::= "typealias" Identifier "=" Type ";" ;
 
 Type            ::= NullableType | NonNullType ;
 NullableType    ::= NonNullType "?" ;
-NonNullType     ::= PrimitiveType
+NonNullType     ::= FundamentalType
+                 | PrimitiveRefType
                  | "String"
                  | "IntArray" | "FloatArray" | "BoolArray" | "CharArray" | "ByteArray" | "PointerArray"
                  | "ObjectArray"
                  | "StringArray"
                  | Identifier ;              // class/interface names (non-primitive)
 
-PrimitiveType   ::= "Int" | "Float" | "Bool" | "Char" | "Byte" | "Pointer" ;
+FundamentalType ::= "int" | "float" | "bool" | "char" | "byte" | "pointer" ;
+PrimitiveRefType ::= "Int" | "Float" | "Bool" | "Char" | "Byte" | "Pointer" ;
 
 Block           ::= "{" { Statement } "}" ;
 Statement       ::= VarDeclStmt | ExprStmt | ReturnStmt | IfStmt | WhileStmt | ForStmt | UnsafeStmt | Block ;
@@ -108,7 +110,7 @@ ForStmt         ::= "for" "(" Identifier "in" Expression ")" Statement ;
 UnsafeStmt      ::= "unsafe" Block ;
 
 Expression      ::= Assignment ;
-Assignment      ::= ElvisExpr [ "=" Assignment ] ;
+Assignment      ::= ElvisExpr [ ("=" | ":=") Assignment ] ;
 
 ElvisExpr       ::= OrExpr [ "?:" ElvisExpr ] ;  // right-assoc
 
@@ -129,8 +131,7 @@ PostfixOp       ::= "." Identifier
                  | "." Identifier "(" [ ArgList ] ")"
                  | "(" [ ArgList ] ")"          // function call or callable object call
                  | "as" Type                    // explicit cast; downcast yields nullable type
-                 | "is" Type                    // type test → Bool
-                 | "!!"                         // non-null assertion
+                 | "is" Type                    // type test → bool
                  | "?." Identifier [ "(" [ ArgList ] ")" ]  // safe call chain
                  | "?." "(" [ ArgList ] ")"     // safe callable object call
                  ;

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -74,11 +74,13 @@ class DefinedFunctional {
 }
 
 val AddNullable: CustomFunctional = pure fun(a: Int?, b: Int?): Int {
-    return (a ?: 0) + (b ?: 0)
+    val aVal: int = a ?: 0  // Conversion from Int? to int
+    val bVal: int = b ?: 0
+    return aVal + bVal
 }
 
 fun Main(args: StringArray): Int {
     // Constructor call then functional call via `call`
-    return AddNullable(2, DefinedFunctional(-1)(2))
+    return AddNullable(2, DefinedFunctional(-1)(2))  // Implicit conversion from literals
 }
 ```

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -2,34 +2,57 @@
 
 Ovum has a rich type system with primitive types and user-defined types. The type system is static and does not permit implicit type coercions (an `Int` won't automatically become a `Float` without an explicit cast, for example).
 
-## Primitive Types
+## Fundamental Types
+
+Fundamental types are passed by value and represent the basic building blocks of the language:
 
 ### Numeric Types
 
-* **`Int`** (8 bytes) - 64-bit signed integer
+* **`int`** (8 bytes) - 64-bit signed integer
   * Literals: `42`, `-17`, `0x1A` (hex), `0b1010` (binary)
   
-* **`Float`** (8 bytes) - 64-bit floating-point number (IEEE 754 double precision)
+* **`float`** (8 bytes) - 64-bit floating-point number (IEEE 754 double precision)
   * Literals: `3.14`, `2.0e10`, `1.5E-3`, `.5`, `5.`
   * Special values: `Infinity`, `-Infinity`, `NaN`
 
-* **`Byte`** (1 byte) - 8-bit unsigned integer
+* **`byte`** (1 byte) - 8-bit unsigned integer
   * Literals: `255`, `0x00`, `0b11111111`
 
 ### Character and Boolean Types
 
-* **`Char`** - single Unicode character (UTF-32)
+* **`char`** - single Unicode character (UTF-32)
   * Literals: `'A'`, `'中'`, `'\n'`, `'\t'`, `'\0'`
 
-* **`Bool`** - Boolean value (`true`, `false`)
-  * Any value can be explicitly cast to `Bool`
+* **`bool`** - Boolean value (`true`, `false`)
+  * Any value can be explicitly cast to `bool`
 
 ### Low-Level Types
 
-* **`Pointer`** - raw memory address *(only meaningful in `unsafe` code)*
+* **`pointer`** - raw memory address *(only meaningful in `unsafe` code)*
   * Used for FFI and low-level memory operations
 
-> **Nullable Primitives**: Any primitive type can be made nullable by appending `?` (e.g., `Int?`, `Float?`, `Bool?`). Nullable primitives are reference types.
+> **Fundamental Type Constraints**: Fundamental types cannot be made nullable (`int?` is invalid). They are not `Object` types and cannot be stored in `ObjectArray` or cast to `Object`. To convert nullable primitives to fundamentals, cast to primitive first: `(nullableInt as Int) as int`.
+
+## Primitive Reference Types
+
+Primitive reference types are built-in reference wrappers around fundamental types, passed by reference:
+
+### Numeric Reference Types
+
+* **`Int`** - reference wrapper for `int` values
+* **`Float`** - reference wrapper for `float` values  
+* **`Byte`** - reference wrapper for `byte` values
+
+### Character and Boolean Reference Types
+
+* **`Char`** - reference wrapper for `char` values
+* **`Bool`** - reference wrapper for `bool` values
+
+### Low-Level Reference Types
+
+* **`Pointer`** - reference wrapper for `pointer` values *(only meaningful in `unsafe` code)*
+
+> **Nullable Primitives**: Any primitive reference type can be made nullable by appending `?` (e.g., `Int?`, `Float?`, `Bool?`).
 
 ## Reference Types
 
@@ -48,12 +71,12 @@ Ovum has a rich type system with primitive types and user-defined types. The typ
 Ovum provides specialized array classes for different element types (no generics/templates):
 
 **Primitive Arrays:**
-* `IntArray` - array of `Int` values
-* `FloatArray` - array of `Float` values  
-* `BoolArray` - array of `Bool` values
-* `CharArray` - array of `Char` values
-* `ByteArray` - array of `Byte` values
-* `PointerArray` - array of `Pointer` values
+* `IntArray` - array of `Int` reference wrappers
+* `FloatArray` - array of `Float` reference wrappers
+* `BoolArray` - array of `Bool` reference wrappers
+* `CharArray` - array of `Char` reference wrappers
+* `ByteArray` - array of `Byte` reference wrappers
+* `PointerArray` - array of `Pointer` reference wrappers
 
 **Object Arrays:**
 * `ObjectArray` - array of any `Object`-derived types
@@ -61,7 +84,7 @@ Ovum provides specialized array classes for different element types (no generics
 
 **Array Creation:**
 ```ovum
-val numbers: IntArray = IntArray(10)        // Create array of size 10
+val numbers: IntArray = IntArray(10)        // Create array of Int reference wrappers
 val names: StringArray = StringArray(5)     // Create string array of size 5
 val objects: ObjectArray = ObjectArray(3)   // Create object array of size 3
 ```
@@ -80,6 +103,26 @@ fun ProcessUser(id: UserId, name: UserName): Void {
 ```
 
 
+## Assignment Operators
+
+### Reference Assignment (`=`)
+
+The standard assignment operator assigns references for reference types:
+
+```ovum
+val original: String = "Hello"
+val reference: String = original  // Both variables point to the same string
+```
+
+### Copy Assignment (`:=`)
+
+The copy assignment operator performs deep copy for reference types:
+
+```ovum
+val original: String = "Hello"
+val copy: String := original  // Creates a new string with the same content
+```
+
 ## Type Casting
 
 ### Explicit Casting
@@ -87,30 +130,49 @@ fun ProcessUser(id: UserId, name: UserName): Void {
 Use the `as` operator for explicit casting:
 
 ```ovum
-val intValue: Int = 42
-val floatValue: Float = (intValue as Float)  // Int to Float
-val stringValue: String = (intValue as String)  // Int to String
+val intValue: int = 42
+val floatValue: float = (intValue as float)  // int to float
 
-val floatNum: Float = 3.14
-val intNum: Int = (floatNum as Int)  // Float to Int (truncates)
+val floatNum: float = 3.14
+val intNum: int = (floatNum as int)  // float to int (truncates)
+
+// Implicit bidirectional casting between fundamental and primitive reference types
+val fundamentalInt: int = 42
+val primitiveInt: Int = fundamentalInt  // Implicit: int -> Int
+val backToFundamental: int = primitiveInt  // Implicit: Int -> int
+
+// Implicit conversion from literals to primitive types
+val count: Int = 0  // Implicit: int literal -> Int
+val flag: Bool = true  // Implicit: bool literal -> Bool
+val pi: Float = 3.14  // Implicit: float literal -> Float
+
+// Arithmetic works seamlessly
+val sum: Int = 10 + 20  // Int + Int = Int (implicit conversion from literals)
+val result: int = sum + 5  // Int + int = int (implicit conversion)
 ```
 
 ### Boolean Casting
 
-Any value can be explicitly cast to `Bool`:
+Any value can be explicitly cast to `bool`:
 
 ```ovum
-val intVal: Int = 42
-val boolVal: Bool = (intVal as Bool)  // true (non-zero)
+val intVal: int = 42
+val boolVal: bool = (intVal as bool)  // true (non-zero)
 
-val zeroInt: Int = 0
-val falseBool: Bool = (zeroInt as Bool)  // false (zero)
+val zeroInt: int = 0
+val falseBool: bool = (zeroInt as bool)  // false (zero)
 
 val nullString: String? = null
-val nullBool: Bool = (nullString as Bool)  // false (null)
+val nullBool: bool = (nullString as bool)  // false (null)
+
+// With primitive reference types (implicit conversion)
+val primitiveInt: Int = 42  // Implicit conversion from literal
+val primitiveBool: bool = primitiveInt  // Implicit: Int -> bool
+val boolRef: Bool = true  // Implicit: bool literal -> Bool
 ```
 
-**Rules:** Primitives: zero → `false`, non-zero → `true`. References: `null` → `false`, non-null → `true`
+**Rules:** Fundamentals and primitive reference types: zero → `false`, non-zero → `true`.
+References: `null` → `false`, non-null → `true`
 
 ### Unsafe Casting
 
@@ -126,17 +188,21 @@ unsafe {
 
 ## Passing Semantics
 
-**Primitive types** are passed by value (copied):
+**Fundamental types** (`int`, `float`, `byte`, `char`, `bool`, `pointer`) are passed by value (copied):
 ```ovum
-fun ModifyInt(x: Int): Void {
+fun ModifyInt(x: int): Void {
     x = x + 1  // Only modifies the local copy
 }
 ```
 
-**Reference types** are passed by reference:
+**Primitive reference types** (`Int`, `Float`, `Byte`, `Char`, `Bool`, `Pointer`) and **all other reference types** (including `String`, arrays, and user-defined types) are passed by reference:
 ```ovum
+fun ModifyIntRef(var x: Int): Void {
+    x = x + 1  // Implicit conversion: Int + int -> Int
+}
+
 fun ModifyArray(arr: IntArray): Void {
-    arr[0] = 999  // Modifies the original array
+    arr[0] := Int(999)  // Use := for deep copy assignment
 }
 ```
 
@@ -156,19 +222,26 @@ fun CanReassign(var str: String): Void {
 **Static typing:** Every variable and expression has a type checked at compile time
 **No implicit conversions:** Explicit casting required between different types
 **Type safety:** Prevents many common errors
-**Nullable types:** Any type can be made nullable by appending `?`
+**Nullable types:** Any reference type (including primitive reference types) can be made nullable by appending `?`. Fundamental types cannot be nullable.
 
 ```ovum
-val x: Int = 42
+val x: int = 42
 val y: String = "Hello"
-// val z: Int = x + y  // ERROR: Cannot add Int and String
+// val z: int = x + y  // ERROR: Cannot add int and String
 
-val intVal: Int = 42
-val floatVal: Float = 3.14
-val result: Float = (intVal as Float) + floatVal  // OK: Explicit conversion
+val intVal: int = 42
+val floatVal: float = 3.14
+val result: float = (intVal as float) + floatVal  // OK: Explicit conversion
 
-val nullableInt: Int? = null
-val nullableString: String? = "Hello"
+// Using primitive reference types (implicit conversion)
+val refInt: Int = 42  // Implicit conversion from literal
+val refFloat: Float = 3.14  // Implicit conversion from literal
+val sum: Int = refInt + refFloat  // Implicit: Int + Float -> Int
+val fundamentalSum: int = sum + 10  // Implicit: Int + int -> int
+
+// Converting nullable primitives to fundamentals
+val nullableInt: Int? = 42  // Implicit conversion from literal
+val fundamentalFromNullable: int = (nullableInt ?: 0) as int  // Two-step conversion
 ```
 
 ## Pure Function Constraints
@@ -189,11 +262,23 @@ Type information is preserved at runtime for reference types:
 ```ovum
 fun ProcessObject(obj: Object): Void {
     if (obj is String) {
-        val str: String = (obj as String)!!
-        sys::Print("String length: " + str.Length().ToString())
+        val str: String? = obj as String
+        if (str != null) {
+            val nonNullStr: String = str ?: "default"  // Use Elvis operator
+            sys::Print("String length: " + nonNullStr.Length().ToString())
+        }
     } else if (obj is IntArray) {
-        val arr: IntArray = (obj as IntArray)!!
-        sys::Print("Array size: " + arr.Length().ToString())
+        val arr: IntArray? = obj as IntArray
+        if (arr != null) {
+            val nonNullArr: IntArray = arr ?: IntArray(0)  // Use Elvis operator
+            sys::Print("Array size: " + nonNullArr.Length().ToString())
+        }
+    } else if (obj is Int) {
+        val intRef: Int? = obj as Int
+        if (intRef != null) {
+            val nonNullInt: Int = intRef ?: 0  // Use Elvis operator
+            sys::Print("Int value: " + nonNullInt.ToString())  // Implicit conversion to string
+        }
     }
 }
 ```


### PR DESCRIPTION
Revise the README.md to clarify the distinction between fundamental types and primitive reference types, emphasizing their characteristics and usage. Update the nullable types section to specify that fundamental types cannot be made nullable and improve examples for null handling. Adjust related documentation across various reference files to ensure consistency in terminology and enhance overall clarity for users.